### PR TITLE
{AD:1.9.2};{SD:1.1.0} --> {AD:1.9.3};{SD:1.1.0}

### DIFF
--- a/Apocrypha.py
+++ b/Apocrypha.py
@@ -1,6 +1,6 @@
 #################
 #   APOCRYPHA   #
-#    V.1.9.2    #
+#    V.1.9.3    #
 #################
 """
 -=#=- Administrative Distribution Internal Documentation [ADID] -=#=-
@@ -32,14 +32,11 @@ class Config:
     The Config class object is used to create an easy library of attributes.
     These dictate the functions of the Apocrypha program.
 
-    allow_cmdln: default True. Dictates whether or not command line can be used given all arguments
-        rather than needing to go through the program step by step. ### CURRENTLY UNIMPLEMENTED ###
     multi_in: default False. Dictates whether or not multiple runs of Apoc will be run on a single file
         containing commands for each separate result. ### CURRENTLY UNIMPLEMENTED ###
     output: default 'print'. Dictates what form the output of Apoc will be given as. Currently
         only supports printing the output. Future support for .txt, .json, and .apoc formats.
     """
-    allow_cmdln: bool = True
     multi_in: bool = False
     output: str = "print"  # in ['print', '.txt', '.json', '.apoc']
 
@@ -52,7 +49,7 @@ def config_subsys(cf: dict) -> dict:
     :return: Dictionary; Modified cf dictionary post-user processing.
     """
     stay = True
-    default = {'allow_cmdln': True, 'multi_in': False, 'output': 'print'}
+    default = {'multi_in': False, 'output': 'print'}
     print("Config Handler Subsystem. Type 'help' for commands.")
     while stay:
         inp = input("> ").lower()
@@ -62,7 +59,6 @@ def config_subsys(cf: dict) -> dict:
             print("Commands:\n"
                   "help: prints out this list\n"
                   "default: Returns all values to their defaults\n"
-                  "allow_cmdln: Allows you to edit the 'allow_cmdln' config option\n"
                   "multi_in: Allows you to edit the 'multi_in' config option\n"
                   "output: Allows you to edit the 'output' config option\n"
                   "exit/quit: Exits the Config Handler Subsystem\n")
@@ -71,14 +67,6 @@ def config_subsys(cf: dict) -> dict:
         elif inp == "default":
             cf = default
             stay = False
-        elif inp == "allow_cmdln":
-            print("allow_cmdln is currently: "+str(cf['allow_cmdln']))
-            print("Valid options: True, False")
-            opt = input(">>> ")
-            if opt in ["True", "False"]:
-                cf['allow_cmdln'] = bool(opt)
-            else:
-                print("Invalid Input.")
         elif inp == "multi_in":
             print("multi_in is currently: "+str(cf['multi_in']))
             print("Valid options: True, False")
@@ -106,7 +94,7 @@ def config_handler(fileloc: str = '', cfSUBSYS: bool = None) -> Config:
     :param cfSUBSYS: bool; None by default, if not None, allows the user to change config options
     :returns: Config object
     """
-    cd = {'allow_cmdln': True, 'multi_in': False, 'output': 'print'}
+    cd = {'multi_in': False, 'output': 'print'}
     cc = json.dumps(cd, sort_keys=True, indent=4)
     if Path('config.json').exists() or (fileloc == '' and Path('config.json').exists()):
         with open('config.json') as file:
@@ -116,7 +104,7 @@ def config_handler(fileloc: str = '', cfSUBSYS: bool = None) -> Config:
                 cc = config_subsys(cc)
                 with open('config.json', 'w') as file:
                     file.write(json.dumps(cc, sort_keys=True, indent=4))
-            return Config(cc['allow_cmdln'], cc['multi_in'], cc['output'])
+            return Config(cc['multi_in'], cc['output'])
         except KeyError:
             print("Error [I.C1]: Invalid config file, you can retry and specify a different JSON file.")
             try:
@@ -137,7 +125,7 @@ def config_handler(fileloc: str = '', cfSUBSYS: bool = None) -> Config:
                 cc = config_subsys(cc)
                 with open('config.json', 'w') as file:
                     file.write(json.dumps(cc, sort_keys=True, indent=4))
-            return Config(cc['allow_cmdln'], cc['multi_in'], cc['output'])
+            return Config(cc['multi_in'], cc['output'])
         except KeyError:
             print("Error [I.C2]: Invalid config file, you can retry and specify a different file location.")
             try:
@@ -158,7 +146,7 @@ def config_handler(fileloc: str = '', cfSUBSYS: bool = None) -> Config:
             cc = config_subsys(cc)
             with open('config.json', 'w') as file:
                 file.write(json.dumps(cc, sort_keys=True, indent=4))
-        return Config(bool(cc['allow_cmdln']), bool(cc['multi_in']), cc['output'])
+        return Config(bool(cc['multi_in']), cc['output'])
 
 
 def expanding_hash(invar: str, length: int = 5000) -> str:
@@ -212,8 +200,7 @@ def Aencode1(config: Config) -> str or None:
     :param config: Config obj; Config object which allows for config options to be utilized.
     :return: str (valid link or custom key) or None (indicative of txt, json, or apoc file)
     """
-    gentype = input("eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: ")
-    gentype = gentype.lower().strip()
+    gentype = input("eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: ").lower().strip()
     if gentype[:6] == "python":
         try:
             pynum = int(gentype[6:].strip())
@@ -276,7 +263,7 @@ def Aencode1(config: Config) -> str or None:
                 print(eAlink)
                 return eAlink
     elif gentype == "file":
-        print("WARNING: If you use a non-Apocrypha text file, it will not be as secure.")
+        print("WARNING: If you use a non-Apocrypha text file, it may not be as secure.")
         return None
     elif gentype == "msg":
         eAkey = input("eA_key = ") + ".msg"
@@ -324,7 +311,6 @@ def Aencode2(config: Config, key: str or None) -> None:
                     os._exit(0)
             except IndexError:
                 os._exit(0)
-        print("WARNING: These characters are known to not be able to be encrypted currently: $^")
         message = input("Message: ")
         messagefinal = []
         if key is not None:
@@ -469,7 +455,8 @@ still best to attempt to only use one instance of list comprehension per charact
   16. Implement a function which simply uses any key to securely use with current method [X]
   17. Implement changing of unused characters in key for any character accepted as valid [X]
   18. Rework <C> option for <A_func> prompt for current config handling not being persistent [X]
-  19. Implement whole base program command line functionality [ ]
+  19. Implement whole base program command line functionality [WIP]
+        Flag idea: [-rf <filepath>] with file with command line arguments on each line.
   20. Introduce dynamic hashing of key to increase size as necessary [ ]
   ??. Implement custom config path persistence securely [ ]
   99. Create a new version which simply uses any key to securely use with no fail state. (Similar to AES) [ ]
@@ -774,8 +761,7 @@ def Adecode1(config: Config) -> str:
     :param config: Config obj; Config object which allows for config options to be utilized.
     :return: Str; File path or key with appended '.msg' string to be processed by Adecode2
     """
-    keyformat = input("dA_k.format[<link{full;param};file;msg>]: ")
-    keyformat = keyformat.lower()
+    keyformat = input("dA_k.format[<link{full;param};file;msg>]: ").lower().strip()
     if keyformat == "linkparam":
         locreq = input("dA_param = ")
         if locreq[0] == '?':
@@ -862,7 +848,7 @@ def Adecode1(config: Config) -> str:
 
 
 def main():
-    print("A_version: 1.9.2")
+    print("A_version: 1.9.3")
     EncOrDec = input("A_func<E;D;C>: ").lower()
     try:
         if EncOrDec[0] == 'e':
@@ -898,5 +884,146 @@ def main():
             os._exit(0)
 
 
+def cmd_ln(args: list) -> dict:
+    """
+    Given a list of arguments from the command line, returns a dictionary of the program procedure and their values.
+    :param args: List; Command Line Arguments sans "Apocrypha.py"
+    :return: Dict; Procedure of the program with values for each prompt.
+    """
+    # flags = [f for f in args if "-" in f[0] or "--" in f[:2]]
+    def err() -> None:
+        print("Usage: python3 Apocrypha.py [--globals] [<function> <key gen/type> <key/filepath> <message>] [-f FILE]")
+        try:
+            if input("Run main (default: No)? [Y]es/[N]o: ").lower().strip()[0] == "y":
+                main()
+            else:
+                os._exit(0)
+        except IndexError:
+            os._exit(0)
+    procedure = {
+        "A_func": None,  # in ["e", "d", None]
+        "eA_gen.type": None,  # in ["file", "msg", None] for 1st iteration
+        "dA.k_format": None,  # in ["file", "msg", None] for 1st iteration
+        "eA_filepath": None,
+        "eA_key": None,
+        "Message": None,
+        "dA_filepath": None,
+        "dA_key": None,
+        "Encrypted Message": None
+    }
+    global_flags = [gf for gf in args if "--" in gf[:2]]
+    arg_flags = [af for af in args if "-" in af[0]]
+    if "--help" in global_flags or "--usage" in global_flags:
+        print("Usage: python3 Apocrypha.py [--globals] [<E;D;C>] [<key gen/type>] [<key/filepath>] [<message>] [-f "
+              "<filepath>]")
+    for argg in args:
+        if argg in global_flags:
+            args.remove(argg)
+    for arg in args:
+        if [procedure['Encrypted Message'], procedure['Message']] == [None, None] and \
+                ([procedure['eA_key'], procedure['dA_key']] != [None, None] or
+                 [procedure['eA_filepath'], procedure['dA_filepath']] != [None, None]):
+            try:
+                if arg != "":
+                    if procedure['eA_key'] is not None or procedure['eA_filepath'] is not None:
+                        procedure['Message'] = arg
+                    elif procedure['dA_key'] is not None or procedure['dA_filepath'] is not None:
+                        procedure['Encrypted Message'] = arg
+                    else:
+                        raise Exception
+            except:
+                print("Error [I.A5]: Command line message input error.")
+                err()
+        elif ([procedure['eA_key'], procedure['dA_key']] == [None, None] or
+                [procedure['eA_filepath'], procedure['dA_filepath']] == [None, None]) and \
+                [procedure['dA.k_format'], procedure['eA_gen.type']] != [None, None]:
+            try:
+                if arg != "":
+                    if procedure['eA_gen.type'] is not None:
+                        if procedure['eA_gen.type'] == "file":
+                            procedure['eA_filepath'] = arg
+                        elif procedure['eA_gen.type'] == "msg":
+                            procedure['eA_key'] = arg
+                        else:
+                            raise Exception
+                    elif procedure['dA.k_format'] is not None:
+                        if procedure['dA.k_format'] == "file":
+                            procedure['dA_filepath'] = arg
+                        elif procedure['dA.k_format'] == "msg":
+                            procedure['dA_key'] = arg
+                        else:
+                            raise Exception
+                    else:
+                        raise Exception
+            except:
+                print("Error [I.A4]: Command line key or filepath error.")
+                err()
+        elif [procedure['dA.k_format'], procedure['eA_gen.type']] == [None, None] and procedure['A_func'] is not None:
+            try:
+                if procedure['A_func'] == "e":
+                    procedure['eA_gen.type'] = arg
+                elif procedure['A_func'] == "d":
+                    procedure['dA.k_format'] = arg
+                else:
+                    raise Exception
+            except:
+                print("Error [I.A3]: Command line key format or generation error.")
+                err()
+        elif procedure['A_func'] is None:
+            try:
+                if arg.lower()[0] in ["e", "d"]:
+                    if arg.lower()[0] == "e":
+                        procedure['A_func'] = "e"
+                    elif arg.lower()[0] == "d":
+                        procedure['A_func'] = "d"
+                    else:
+                        raise IndexError
+            except IndexError:
+                print("Error [I.A2]: A_func command line processing error.")
+                err()
+        else:
+            print("Error [I.A1]: Else condition met in cmd_ln() function.")
+            err()
+    return procedure
+
+
+def cmd_main(argvs: list) -> None:
+    """
+    The main program for the command line.
+    :param argvs: List; Command line arguments sans given "Apocrypha.py"
+    :return: None; Calls other functions to carry out functionality as necessary.
+    """
+    print("Command Line Usage: python3 Apocrypha.py [--help;--usage]\n"
+          "Limited Command Line functionality has been implemented.\n")
+    prog = cmd_ln(argvs)
+    config = config_handler()
+    if prog['A_func'] is None:
+        main()
+    elif prog['A_func'] is not None and [prog['eA_gen.type'], prog['dA.k_format']] == [None, None]:
+        if prog['A_func'] == "e":
+            k = Aencode1(config)
+            Aencode2(config, k)
+        elif prog['A_func'] == "d":
+            Adecode2(config, Adecode1(config))
+        else:
+            print("Error [I.P1]: Program command line processing error in A_func logic.\nRunning main")
+            main()
+    elif prog['eA_gen.type'] == "file" and prog['eA_filepath'] is None:
+        Aencode2(config, None)
+    elif prog['eA_gen.type'] == "msg" and prog['eA_key'] is not None and prog['Message'] is None:
+        Aencode2(config, prog['eA_key'] + ".msg")
+    elif prog['dA_key'] is not None and prog['Encrypted Message'] is None:
+        Adecode2(config, prog['dA_key'] + ".msg")
+    elif prog['dA_filepath'] is not None and prog['Encrypted Message'] is None:
+        Adecode2(config, prog['dA_filepath'])
+    else:
+        print("Unimplemented command line case, running main program")
+        main()
+
+
 if __name__ == "__main__":
-    main()
+    args = sys.argv[1:]
+    if len(args) == 0:
+        main()
+    else:
+        cmd_main(args)

--- a/Apocrypha_stable.py
+++ b/Apocrypha_stable.py
@@ -270,7 +270,7 @@ def Aencode1(config: Config) -> str or None:
                 print(eAlink)
                 return eAlink
     elif gentype == "file":
-        print("WARNING: If you use a non-Apocrypha text file, it will not be as secure.")
+        print("WARNING: If you use a non-Apocrypha text file, it may not be as secure.")
         return None
     elif gentype == "msg":
         eAkey = input("eA_key = ") + ".msg"
@@ -318,7 +318,6 @@ def Aencode2(config: Config, key: str or None) -> None:
                     os._exit(0)
             except IndexError:
                 os._exit(0)
-        print("WARNING: These characters are known to not be able to be encrypted currently: $^")
         message = input("Message: ")
         messagefinal = []
         if key is not None:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 #################
 #   APOCRYPHA   #
 #   CHANGELOG   #
-#    V.1.9.2    #
+#    V.1.9.3    #
 #    V.1.1.0    #
 #################
 [Sept. 2, 2021] 1.7.1 --> 1.7.5
@@ -176,3 +176,21 @@ For the future implementation:
 {SD} 1.0.1 --> 1.1.0 (Version 5 --> 6) == {AD} 1.8.7 --> 1.9.2
  + Ability to now encrypt all characters even without them being present in the key.
  & All other features and changes made to {AD} 1.9.2 as described above, these versions are equivalent.
+
+[Jan. 31 - Feb. 2, 2022]
+{AD} 1.9.2 --> 1.9.3
+ + Added limited command line functionality, large rewrite necessary for full command line functionality currently.
+ - Removed allow_cmdln from Config, as it's effectively unnecessary to potentially config-block a feature.
+{SD} 1.1.0
+ ~ Small semantic change to a warning message when using the custom file option.
+{DOCS}
+ ~ Updated readme documentation and error codes documentation.
+ + Added Usage section to readme.md so that use of the program is explained and accessible.
+{PLANS}
+ ~ Apocrypha 2.0 will come with a large rewrite/overhaul of the current organization such that full
+    command line functionality is possible (that being any number of arguments can be passed and the program
+    can pick up where the arguments have yet to be fulfilled)
+ ~ Ideally, I'd also like to implement the dynamic hashing of the key to match the size of the message.
+    This would scale the time complexity as necessary and overall increase efficiency.
+ ~ New and improved documentation including standardization of symbol/entry meanings!
+    No more random symbols which happen to describe what I think would be good for that entry at that moment.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-    "allow_cmdln": true,
     "multi_in": false,
     "output": "print"
 }

--- a/errorcodes.md
+++ b/errorcodes.md
@@ -1,7 +1,7 @@
 # Error Codes
 
 ### Up to date with
-![version](https://img.shields.io/badge/Admin_Version-1.9.2-blue.svg)
+![version](https://img.shields.io/badge/Admin_Version-1.9.3-blue.svg)
 ![stableversion](https://img.shields.io/badge/Stable_Version-1.1.0-brightgreen.svg)
 
 Error codes are up-to-date with the latest Admin Distribution, errors found in the Stable Distribution are consistent
@@ -48,6 +48,41 @@ valid config file for the program. I.C2 signifies a custom filepath for the conf
 It's highly recommended to just use the default config file and edit it as necessary, but default values should suffice
 for most widespread usage. You can delete the config file and rerun the program which will automatically generate a new
 valid config file in its place. You can regain default settings this way for your config file.
+
+### I.A1
+>"Error [I.A1]: Else condition met in cmd_ln() function."
+
+Originates in the `cmd_ln` function when the else is triggered. This means for whatever reason, there is something wrong
+with the initialization of the procedure dictionary which processes the command line arguments passed as the main
+program would prompt.
+
+### I.A2
+>"Error [I.A2]: A_func command line processing error."
+
+Originates in the `cmd_ln` function when the first command line argument is invalid.
+
+This is likely due to the first argument not being either "e" or "d". NOTE: You can have anything as the first argument,
+so long as the first letter is either an `e` or `d`, the program automatically checks the first letter after making it
+lowercase, so it is also not case-sensitive for this option. So `EXIT` as a first command line argument will be
+processed as a valid `e` input for the `A_func` prompt via command line, just as it is in the main program.
+
+### I.A3
+>"Error [I.A3]: Command line key format or generation error."
+
+Originates in the `cmd_ln` function when the eA.gen_type or dA.k_format fail.
+This is likely due to an invalid `A_func` prompt input.
+
+### I.A4
+>"Error [I.A4]: Command line key or filepath error."
+
+Originates in the `cmd_ln` function when the key/msg or filepath is being processed.
+Likely due to an invalid key format from either encryption or decryption, or None values for both.
+
+### I.A5
+>"Error [I.A5]: Command line message input error."
+
+Originates in the `cmd_ln` function when the final message-to-be-encrypted or encrypted message throws an exception.
+This is likely due to the key and filepath procedure dictionary entries are both None.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 ## Description
 
-![version](https://img.shields.io/badge/Admin_Version-1.9.2-blue.svg)
+![version](https://img.shields.io/badge/Admin_Version-1.9.3-blue.svg)
 ![stableversion](https://img.shields.io/badge/Stable_Version-1.1.0-brightgreen.svg)
 ![documentation](https://img.shields.io/badge/documentation-passing-brightgreen.svg)
 
@@ -32,6 +32,253 @@ changing the key as it encrypts.
 ----
 ----
 
+## Usage
+
+_This guide will walkthrough a set of basic scenarios for encryption, decryption, and using the config modification
+subsystem. NOTE: This guide won't walk through EVERY scenario, but will explain inputs in each example run._
+
+The `|` character will indicate where an input is requested from the user.
+
+---
+
+###How to encrypt with a custom message.
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: |
+```
+
+From here you can enter anything that starts with the letters `e`, `d`, or `c` as valid input options, in our case, we
+want to enter anything that begins with the letter `e`. Inputs here are _NOT_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: e
+eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: |
+```
+
+Here is the encryption prompt for the key format to either be generated or used. In this case, we want to use a custom
+message, so we input `msg`. NOTE: Inputs here are _NOT_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: e
+eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: msg
+eA_key = |
+```
+
+Here you input what key you want to use for encrypting your message. This _IS_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: e
+eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: msg
+eA_key = This is a custom key
+Message: |
+```
+
+Here is where you input the message you want to encrypt with your entered custom key. All characters on a standard en_US
+keyboard have been confirmed to work, and in theory, all Unicode characters should work as well, but this is not tested.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: e
+eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: msg
+eA_key = This is a custom key
+Message: Super Seeecret Message!
+
+Time: 0.005131959915161133
+
+Encrypted Message:
+
+[[685, 2910, 2985, 3999, 4195, 3460, 3522, 3629, 3724, 4595, 4916, 736, 687, 1001, 3472, 1758, 1618, 4823, 4127, 4337, 4770, 1697, -933, 3399], '22c8c32bd4ef6a7490f11607b9dd4e1f97a01089339d0eacdf27669da8450a72']
+
+Press enter when done: |
+```
+
+Now you have the encrypted message as well as how long it took to encrypt the message printed out for you for copying
+and sending. The string of numbers is the encrypted message itself, so in a pinch, you can send just that (NOTE: _MUST_
+include the square brackets, eg `[1, 2, 3]`). The string of numbers and letters after the list of numbers is the final
+hash of the key after encryption used to guarantee during decryption that the message matches with the key.
+
+---
+
+###How to decrypt with a custom message
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: |
+```
+
+From here you can enter anything that starts with the letters `e`, `d`, or `c` as valid input options, in our case, we
+want to enter anything that begins with the letter `d`. Inputs here are _NOT_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: d
+dA_k.format[<link{full;param};file;msg>]: |
+```
+
+Here is the decryption prompt for the key format to either be generated or used. In this case, we want to use a custom
+message, so we input `msg`. NOTE: Inputs here are _NOT_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: d
+dA_k.format[<link{full;param};file;msg>]: msg
+dA_key = |
+```
+
+Here you input what key you want to use for decrypting your message. This _IS_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: d
+dA_k.format[<link{full;param};file;msg>]: msg
+dA_key = This is a custom key
+dA_eM: |
+```
+
+Here is where you enter the encrypted message. It should, in a basic form, look something similar to
+`[[1, 2, 3], '2uh75vh32ilu3v25bo873eljt325h1']`, although much longer.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: d
+dA_k.format[<link{full;param};file;msg>]: msg
+dA_key = This is a custom key
+dA_eM: [[685, 2910, 2985, 3999, 4195, 3460, 3522, 3629, 3724, 4595, 4916, 736, 687, 1001, 3472, 1758, 1618, 4823, 4127, 4337, 4770, 1697, -933, 3399], '22c8c32bd4ef6a7490f11607b9dd4e1f97a01089339d0eacdf27669da8450a72']
+Decrypted Message:
+
+Super Seeecret Message!
+
+Key Hash Match: True
+
+Message Final Key Hash: 22c8c32bd4ef6a7490f11607b9dd4e1f97a01089339d0eacdf27669da8450a72
+Current Final Key Hash: 22c8c32bd4ef6a7490f11607b9dd4e1f97a01089339d0eacdf27669da8450a72
+Start Initial Key Hash: 6a1760f236570743b0f06a790bc93ee972972d8f22bbbbe36e6af94babadb9a2
+
+Press enter to close the program. |
+```
+
+Here you have the results of your decryption, complete with what the decrypted message is, if the final key hashes
+matched, what they were, and what the initial key hash was.
+
+---
+
+####Using the config subsystem
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: |
+```
+
+From here you can enter anything that starts with the letters `e`, `d`, or `c` as valid input options, in our case, we
+want to enter anything that begins with the letter `c`. Inputs here are _NOT_ case-sensitive.
+
+---
+
+```
+A_version: 1.9.3
+A_func<E;D;C>: c
+NOTE: Only a 'config.json' file in the same directory as Apocrypha.py will be accepted currently
+Config Handler Subsystem. Type 'help' for commands.
+> |
+```
+
+The `help` command in the config handler subsystem acts as its own usage guide, as it's not recommended modifying config
+settings unless you really know what you're doing. (Note: Currently, as of {AD} 1.9.3, the config currently has no real
+functionality, this is planned to change, but all modifiable functionality previously has been integrated already.)
+
+---
+
+###Limited Command Line Functionality
+
+You can bypass certain prompts using the command line to streamline the process of encryption and decryption, but
+currently, a prompted input is still required even given command line arguments.
+
+_Full command line functionality and support given any number of arguments is planned for the future along with a
+rewrite of the program as a whole to allow this functionality._
+
+---
+
+>To get the usage message for the command line
+
+`python3 Apocrypha.py --help`
+OR
+`python3 Apocrypha.py --usage`
+
+`Usage: python3 Apocrypha.py [--globals] [<E;D;C>] [<key gen/type>] [<key/filepath>] [<message>] [-f <filepath>]`
+
+NOTE: Non-global flags shown in the usage message (eg. `[-f <filepath>]`) haven't been implemented yet.
+
+The program then runs the program according to the rest of the arguments given, otherwise runs the main program.
+
+---
+
+>To begin the encryption process from `eA_gen.type` prompt
+
+`python3 Apocrypha.py e`
+
+---
+
+>To begin the decryption process from `dA_k.format` prompt
+
+`python3 Apocrypha.py d`
+
+---
+
+>To use a custom message in encryption, key pre-entered.
+>If the key is a single word, quotations are not needed.
+
+`python3 Apocrypha.py e msg "This is a custom key"`
+
+You will be prompted for the `Message:` to encrypt.
+
+---
+
+>To use a custom message in decryption, key pre-entered.
+>If the key is a single word, quotations are not needed.
+
+`python3 Apocrypha.py d msg "This is a custom key"`
+
+You will be prompted with `dA_eM:` for the encrypted message to decrypt.
+
+---
+
+>To use a custom file in encryption
+
+`python3 Apocrypha.py e file`
+
+You will be prompted for `eA_filepath` and continue from there.
+
+---
+
+>To use a custom file in decryption, filepath given
+
+`python3 Apocrypha.py d file <filepath>`
+
+You will be prompted for the `Encrypted Message:` to decrypt.
+
+----
+----
+
 ## Documentation
 
 ### Class Objects
@@ -40,11 +287,6 @@ changing the key as it encrypts.
 
 The `Config` class object is used to create an easy library of attributes.
 These dictate the functions of the Apocrypha program.
-
----
----
-
->######TO BE IMPLEMENTED: `allow_cmdln`: default `True`. Dictates whether or not command line can be used given all arguments rather than needing to go through the program step by step.
 
 ---
 
@@ -64,9 +306,9 @@ only supports printing the output. Future support for .txt, .json, and .apoc for
 
 _Generates and returns a key to be used for encryption in Aencode2._
 
->Parameter _config:_ Config object which allows for config options to be utilized.
+>Parameter `config`: `Config` object which allows for config options to be utilized.
 > 
->Returns: str (valid link) or None (indicative of txt, json, or apoc file)
+>Returns: `str` (valid link) or `None` (indicative of txt, json, or apoc file)
 
 The first step in the Apocrypha encryption process. Works to determine the key that'll be used,
 and create one if necessary. Takes user input to create either a link using the secrets module as
@@ -97,16 +339,12 @@ The program then prompts for the message the user wants to encrypt after validat
 It then encrypts the message using the Apocrypha method: Find and compile a list of all indexes of characters matching
 the current character being encrypted of the message in the key. It then selects a random one of those characters
 and deletes it from the key file, which then changes the file to then repeat the process until the message is complete.
+If the character is not present in the key, then a random character is selected, and that key is used for its location.
+That character selected from the key's ord is then multiplied by the character the user is encrypting's ord value.
 It finally gets the hash of the final result of the key after encryption as a unique identifier of that encryption.
 
 This method allows for the same key and the same message to have multiple encrypted versions while all decrypting to the
 same original message given the same initial key and message.
-
-NOTE: For characters not found in the key, as of {AD} 1.9.0, it will take a position of an unused character (a character
-in the key but not found in the message), and use its position as the base, then invert the ord and multiply by -1 as an
-indicator of it being a 'custom' character. This version of 'custom' character encryption will be changed to be more
-secure and reliable, as the current iteration doesn't always reliably work, many examples can be found in comments in
-{AD} which detail how it was made, what it was supposed to decrypt to, and what it actually decrypted to.
 
 ---
 
@@ -196,6 +434,36 @@ starts and ends.
 Finally, it creates a list to pass onto the loop portion of the function which will continue this process until the
 length parameter is met for the final key. The list passed onto the loop is the result of the first iteration but sliced
 into 4 equal length segments to then by hashed individually to repeat the process and expand the final key.
+
+---
+
+####`cmd_ln(args: list) -> dict`
+
+_Given a list of arguments from the command line, returns a dictionary of the program procedure and their values._
+
+>Parameter `args`: List of command line arguments sans "Apocrypha.py"
+>
+>Returns `dict`: Dictionary containing prompts 'pre-filled' by command line arguments.
+
+Processes a list of arguments which then builds a dictionary given each prompt of the program along with their values
+which is then later returned to be processed for functionality. If a given prompt/functional part of the program isn't
+used given a certain path the arguments follow, fields are by default None in the dictionary.
+
+Contains an internal function `err()` which is an error handling function which can run the main program if any command
+line arguments throws an error either in their own right, or from the `cmd_ln` function in its own right.
+
+---
+
+####`cmd_main(argvs: list) -> None`
+
+_The main program for the command line._
+
+>Parameter `argvs`: List of command line arguments sans "Apocrypha.py"
+>
+>Returns `None`: Calls other functions to carry out functionality as necessary.
+
+The `cmd_main` function passes the list of arguments to the `cmd_ln` function which the returned dictionary is used for
+processing the command line arguments as to what to do functionally.
 
 ---
 


### PR DESCRIPTION
Update {AD} 1.9.2; {SD} 1.1.0 (Version 6) on master to {AD} 1.9.3; {SD} 1.1.0 (Version 6)

{SD} 1.1.0 (Version 6) has only 1 minor semantic change in a warning message.
{AD} 1.9.2 on master branch to be updated to {AD} 1.9.3, skipping over no versions developed and pushed onto the `admin` branch.

{AD} 1.9.3 major updates list from {AD} 1.9.2:
- Removed `allow_cmdln` config option
- Implemented limited command line functionality with `cmd_main` and `cmd_ln` functions
- Added Usage section to `readme.md`