### PR TITLE
{AD:1.9.4};{SD:1.1.1} --> {AD:1.9.4};{SD:1.1.1}

### DIFF
--- a/Apocrypha.py
+++ b/Apocrypha.py
@@ -22,11 +22,9 @@ from pathlib import Path
 from math import floor, sqrt
 from string import ascii_letters
 from blake3 import blake3 as bl3
-from dataclasses import dataclass
 from base64 import b64encode as b64e
 
 
-@dataclass
 class Config:
     """
     The Config class object is used to create an easy library of attributes.
@@ -34,11 +32,15 @@ class Config:
 
     multi_in: default False. Dictates whether or not multiple runs of Apoc will be run on a single file
         containing commands for each separate result. ### CURRENTLY UNIMPLEMENTED ###
-    output: default 'print'. Dictates what form the output of Apoc will be given as. Currently
+    output: default 'print'. Dictates what form the output of Apoc will be given as. Currently,
         only supports printing the output. Future support for .txt, .json, and .apoc formats.
     """
     multi_in: bool = False
     output: str = "print"  # in ['print', '.txt', '.json', '.apoc']
+
+    def __init__(self, multi_in: bool, output: str):
+        self.multi_in = multi_in
+        self.output = output
 
 
 def config_subsys(cf: dict) -> dict:

--- a/Apocrypha_stable.py
+++ b/Apocrypha_stable.py
@@ -16,11 +16,9 @@ from pathlib import Path
 from math import floor, sqrt
 from string import ascii_letters
 from blake3 import blake3 as bl3
-from dataclasses import dataclass
 from base64 import b64encode as b64e
 
 
-@dataclass
 class Config:
     """
     The Config class object is used to create an easy library of attributes.
@@ -28,11 +26,15 @@ class Config:
 
     multi_in: default False. Dictates whether or not multiple runs of Apoc will be run on a single file
         containing commands for each separate result. ### CURRENTLY UNIMPLEMENTED ###
-    output: default 'print'. Dictates what form the output of Apoc will be given as. Currently
+    output: default 'print'. Dictates what form the output of Apoc will be given as. Currently,
         only supports printing the output. Future support for .txt, .json, and .apoc formats.
     """
     multi_in: bool = False
     output: str = "print"  # in ['print', '.txt', '.json', '.apoc']
+
+    def __init__(self, multi_in: bool, output: str):
+        self.multi_in = multi_in
+        self.output = output
 
 
 def config_subsys(cf: dict) -> dict:

--- a/changelog.txt
+++ b/changelog.txt
@@ -202,3 +202,27 @@ For the future implementation:
  @ Above changes made from {AD} 1.9.2 to {AD} 1.9.4 will be applied.
 {PLANS}
  ~ With this update, the Apocrypha.py 2.0 rewrite begins. When complete, a Java port will begin development.
+
+[Feb. 28, 2022]
+{AD} 1.9.4 ***
+ - Removed the dataclass package and usage with native Python class definition
+***NOTE: This change is functionally equivalent to the previous version 1.9.4,
+    thus there's no name change here, especially with the 2.0 rewrite in the works
+{SD} 1.1.1 (Version 7) ***
+***NOTE: Same changelog notes as above.
+{PLANS}
+ ~ Update to the plans as written from Feb. 2, the Java port is underway, being written in the same form the
+    Python 2.0 rewrite will take shape. The Java port will sadly not be compatible with the Python version in terms
+    of encryption and decryption currently due to library limitations, this may be reworked in the far future
+    for cross-compatibility, but this is far from a promise, more an acknowledgement that it could, but most likely
+    won't happen.
+ ~ In terms of progress on the Java port, the repository is currently private and will be made public when it is
+    finished. Currently, the equivalent of expanding_hash(), Aencode1(), and Adecode1() are complete.
+ ~ The Python Apocrypha 2.0 rewrite will likely begin once the Java port is complete, being used as a model for the
+    rewrite.
+ ~ The 2.0 rewrite won't simply be all current features but written in an Object-Oriented style, rather it'll implement
+    new features that required the rewrite, namely full command line program functionality, and updated documentation.
+    (We'll ignore that I could update documentation now, I'll do that retroactively for the final Version 7 release)
+ ~ Random new planned feature: Global flag [--default] to be able to run the program ignoring any existing config.json
+    file. We'll see if I can implement this, but: Could also then run without creating a config.json file if one doesn't
+    exist already given this global flag. Possible other flag names: [--noconfig, --defconfig, --dc, --nc]

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ The `|` character will indicate where an input is requested from the user.
 ###How to encrypt with a custom message.
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: |
 ```
 
@@ -54,7 +54,7 @@ want to enter anything that begins with the letter `e`. Inputs here are _NOT_ ca
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: e
 eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: |
 ```
@@ -65,7 +65,7 @@ message, so we input `msg`. NOTE: Inputs here are _NOT_ case-sensitive.
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: e
 eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: msg
 eA_key = |
@@ -76,7 +76,7 @@ Here you input what key you want to use for encrypting your message. This _IS_ c
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: e
 eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: msg
 eA_key = This is a custom key
@@ -89,7 +89,7 @@ keyboard have been confirmed to work, and in theory, all Unicode characters shou
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: e
 eA_gen.type[<python{INT};apocrypha;custom{full;param};file;msg>]: msg
 eA_key = This is a custom key
@@ -114,7 +114,7 @@ hash of the key after encryption used to guarantee during decryption that the me
 ###How to decrypt with a custom message
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: |
 ```
 
@@ -124,7 +124,7 @@ want to enter anything that begins with the letter `d`. Inputs here are _NOT_ ca
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: d
 dA_k.format[<link{full;param};file;msg>]: |
 ```
@@ -135,7 +135,7 @@ message, so we input `msg`. NOTE: Inputs here are _NOT_ case-sensitive.
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: d
 dA_k.format[<link{full;param};file;msg>]: msg
 dA_key = |
@@ -146,7 +146,7 @@ Here you input what key you want to use for decrypting your message. This _IS_ c
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: d
 dA_k.format[<link{full;param};file;msg>]: msg
 dA_key = This is a custom key
@@ -159,7 +159,7 @@ Here is where you enter the encrypted message. It should, in a basic form, look 
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: d
 dA_k.format[<link{full;param};file;msg>]: msg
 dA_key = This is a custom key
@@ -185,7 +185,7 @@ matched, what they were, and what the initial key hash was.
 ####Using the config subsystem
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: |
 ```
 
@@ -195,7 +195,7 @@ want to enter anything that begins with the letter `c`. Inputs here are _NOT_ ca
 ---
 
 ```
-A_version: 1.9.3
+A_version: 1.9.4
 A_func<E;D;C>: c
 NOTE: Only a 'config.json' file in the same directory as Apocrypha.py will be accepted currently
 Config Handler Subsystem. Type 'help' for commands.


### PR DESCRIPTION
Update {AD:1.9.4};{SD:1.1.1} on master with {AD:1.9.4};{SD:1.1.1} on admin.

NOTE: These versions are functionally equivalent. Only minor changes were made in removing the dataclass package and instead using native Python class features.

The changelog has been updated with the latest info on plans as well, namely that of the current status of the Apocrypha 2.0 rewrite and the Java port. The readme has also been updated in the usage examples with the version being the latest.

This should be noted as one of the last Apocrypha 1.0 merges except for the planned final documentation update, or bug fixes.